### PR TITLE
修改了对Domain正则匹配

### DIFF
--- a/src/main/java/burp/Utils.java
+++ b/src/main/java/burp/Utils.java
@@ -20,7 +20,7 @@ public class Utils {
     }
 
     public static boolean isMathch(String regx,String str){
-        Pattern pat = Pattern.compile("[\\w]+[\\.]("+regx+")",Pattern.CASE_INSENSITIVE);//正则判断
+        Pattern pat = Pattern.compile("([\\w]+[\\.]|)("+regx+")",Pattern.CASE_INSENSITIVE);//正则判断
         Matcher mc= pat.matcher(str);//条件匹配
         if(mc.find()){
             return true;


### PR DESCRIPTION
修改了Utils.java中对Domain的正则匹配规则
在Domain处输入example.com时，可以同时匹配example.com和其子域名xxx.example.com