### PR TITLE
Update HttpAndHttpsProxy.java，否则有的站点校验origin和referer会bug

### DIFF
--- a/src/main/java/burp/HttpAndHttpsProxy.java
+++ b/src/main/java/burp/HttpAndHttpsProxy.java
@@ -91,7 +91,7 @@ public class HttpAndHttpsProxy {
                         header.startsWith("PUT")){
                     continue;
                 }
-                String[] h = header.split(":");
+                String[] h = header.split(": ");
                 String header_key = h[0].trim();
                 String header_value = h[1].trim();
                 httpsConn.setRequestProperty(header_key, header_value);
@@ -218,7 +218,7 @@ public class HttpAndHttpsProxy {
                         header.startsWith("PUT")){
                     continue;
                 }
-                String[] h = header.split(":");
+                String[] h = header.split(": ");
                 String header_key = h[0].trim();
                 String header_value = h[1].trim();
                 //BurpExtender.stdout.println("key: " + h[0].trim());


### PR DESCRIPTION
开始String[] h = header.split(":"); 直接用冒号截断导致有的情况下
Origin: https://xxx.com
Referer: https://xxx.com
被截断成
Origin: https
Referer: https
 新加了个空格