### PR TITLE
Update HttpAndHttpsProxy.java

### DIFF
--- a/src/main/java/burp/HttpAndHttpsProxy.java
+++ b/src/main/java/burp/HttpAndHttpsProxy.java
@@ -75,7 +75,7 @@ public class HttpAndHttpsProxy {
             httpsConn = (HttpsURLConnection) urlClient.openConnection(proxy1);
 
             //设置账号密码
-            if(username != null && username != "" && password != null && password != "" ) {
+            if(username != null && username == "" && password == null && password != "" ) {
                 String user_pass = String.format("%s:%s", username, password);
                 String headerKey = "Proxy-Authorization";
                 String headerValue = "Basic " + Base64.encode(user_pass.getBytes());


### PR DESCRIPTION
经调试发现第78行判断出现问题，username和password传入值为""，username !=""和password != ""返回为真，故空密码执行为真语句，导致抛出异常。只需将username !=""和password != ""修改为username ==""和password == ""即可解决问题。在burpsuit2022.8.2成功使用插件联动XRAY
![测试图](https://user-images.githubusercontent.com/36194017/187449305-ff91e27e-c95a-43b4-975d-125f63c62493.png)
